### PR TITLE
Fixed roslaunch file name mismatch for the example node.

### DIFF
--- a/behavior_tree_leaves/launch/test_behavior_tree.launch
+++ b/behavior_tree_leaves/launch/test_behavior_tree.launch
@@ -1,5 +1,5 @@
 <launch>
-  <node name="action" pkg="behavior_tree_leaves" type="ActionExample" />
-  <node name="condition" pkg="behavior_tree_leaves" type="ConditionExample" />
+  <node name="action" pkg="behavior_tree_leaves" type="action_example" />
+  <node name="condition" pkg="behavior_tree_leaves" type="condition_example" />
   <node name="tree" pkg="behavior_tree_core" type="tree" />
 </launch>

--- a/behavior_tree_leaves/launch/test_behavior_tree.launch~
+++ b/behavior_tree_leaves/launch/test_behavior_tree.launch~
@@ -1,0 +1,5 @@
+<launch>
+  <node name="action" pkg="behavior_tree_leaves" type="ActionExample" />
+  <node name="condition" pkg="behavior_tree_leaves" type="ConditionExample" />
+  <node name="tree" pkg="behavior_tree_core" type="tree" />
+</launch>


### PR DESCRIPTION
Hi miccol;

Well, I think am now returning to the idea of using your ROS-Behaviour-Tree library. I am planning to use it for my PhD research purposes. I plan to understand your library and possibly start contributing to it, if indeed I continue using it. Here, by the way, comes a very small contribution in order to fix a small bug in the launch file for the example node.

Fixed a "can't locate node" error caused by a mismatch in the type of the example node for condition_example and action_examples executables

Details:
 
**ERROR: cannot launch node of type [behavior_tree_leaves/ActionExample]: can't locate node [ActionExample] in package [behavior_tree_leaves]**

**ERROR: cannot launch node of type [behavior_tree_leaves/ConditionExample]: can't locate node [ConditionExample] in package [behavior_tree_leaves]**


Best Regards.