### PR TITLE
Fix build warnings

### DIFF
--- a/behavior_tree_core/include/draw.h
+++ b/behavior_tree_core/include/draw.h
@@ -26,7 +26,7 @@ void drawTree(BT::ControlNode* tree_);
 
 void draw_status(float x, float y, int node_status);
 
-void drawString(void * font, char *string, float x, float y, float z);
+void drawString(void * font, const char *string, float x, float y, float z);
 
 void renderBitmapString(float x, float y, void *font, const char *string);
 

--- a/behavior_tree_core/src/actions/ros_action.cpp
+++ b/behavior_tree_core/src/actions/ros_action.cpp
@@ -15,7 +15,9 @@
 #include <string>
 
 
-BT::ROSAction::ROSAction(std::string name) : action_client_(name, true), ActionNode::ActionNode(name)
+BT::ROSAction::ROSAction(std::string name) :
+  ActionNode::ActionNode(name),
+  action_client_(name, true)
 {
     actionlib::SimpleActionClient<behavior_tree_core::BTAction> action_client_(get_name(), true);
     ROS_INFO("Waiting For the Acutator named %s to start", get_name().c_str());

--- a/behavior_tree_core/src/conditions/ros_condition.cpp
+++ b/behavior_tree_core/src/conditions/ros_condition.cpp
@@ -17,7 +17,9 @@
 enum Status {RUNNING, SUCCESS, FAILURE};
 
 
-BT::ROSCondition::ROSCondition(std::string name) : action_client_(name, true), ConditionNode::ConditionNode(name)
+BT::ROSCondition::ROSCondition(std::string name) :
+  ConditionNode::ConditionNode(name),
+  action_client_(name, true)
 {
     ROS_INFO("Waiting For the Acutator named %s to start", get_name().c_str());
     action_client_.waitForServer();  // will wait for infinite time until the server starts

--- a/behavior_tree_core/src/control_node.cpp
+++ b/behavior_tree_core/src/control_node.cpp
@@ -18,7 +18,10 @@
 BT::ControlNode::ControlNode(std::string name) : TreeNode::TreeNode(name)
 {
     type_ = BT::CONTROL_NODE;
-    ReturnStatus child_i_status_ = BT::IDLE;
+
+    // TODO(...) In case it is desired to set to idle remove the ReturnStatus
+    // type in order to set the member variable
+    // ReturnStatus child_i_status_ = BT::IDLE;  // commented out as unused
 }
 
 BT::ControlNode::~ControlNode() {}

--- a/behavior_tree_core/src/control_node.cpp
+++ b/behavior_tree_core/src/control_node.cpp
@@ -92,7 +92,7 @@ int BT::ControlNode::Depth()
 {
     int depMax = 0;
     int dep = 0;
-    for (int i = 0; i < children_nodes_.size(); i++)
+    for (unsigned int i = 0; i < children_nodes_.size(); i++)
     {
         dep = (children_nodes_[i]->Depth());
         if (dep > depMax)

--- a/behavior_tree_core/src/draw.cpp
+++ b/behavior_tree_core/src/draw.cpp
@@ -250,7 +250,7 @@ void draw_edge(GLfloat parent_x, GLfloat parent_y,
 {
     glLineWidth(1.5);
     glColor3f(0.0, 0.0, 0.0);
-    GLfloat bottom_spacing = 0.1;
+    // GLfloat bottom_spacing = 0.1;  // commented-out as unused variable
     GLfloat above_spacing = 0.04;
 
     glBegin(GL_LINES);
@@ -342,7 +342,7 @@ void updateTree(BT::TreeNode* tree, GLfloat x_pos, GLfloat y_pos, GLfloat y_offs
         std::vector<GLfloat> children_x_middle_relative;
 
         GLfloat max_x_end = 0;
-        GLfloat max_x_start = 0;
+        // GLfloat max_x_start = 0;  // commented out as unused variable
         GLfloat current_x_end = 0;
 
         for (int i = 0; i < M; i++)
@@ -369,10 +369,10 @@ void updateTree(BT::TreeNode* tree, GLfloat x_pos, GLfloat y_pos, GLfloat y_offs
             children_x_end.push_back(max_x_end);
         }
 
-        GLfloat x_min = 0.0;
-        GLfloat x_max = 0.0;
+        // GLfloat x_min = 0.0;  // commented-out as unused variable
+        // GLfloat x_max = 0.0;  // commented-out as unused variable
         GLfloat x_shift = x_pos - max_x_end/2;
-        GLfloat x_shift_new = 0;
+        // GLfloat x_shift_new = 0;  // commented-out as unused variable
 
         for (int i = 0; i < M; i++)
         {

--- a/behavior_tree_core/src/draw.cpp
+++ b/behavior_tree_core/src/draw.cpp
@@ -64,7 +64,7 @@ void drawEllipse(float xpos, float ypos, float xradius, float yradius)
     glEnd();
 }
 
-void drawString(void * font, char *string, float x, float y, float z)
+void drawString(void * font, const char *string, float x, float y, float z)
 {
     renderBitmapString(x, y, font, string);
 }

--- a/behavior_tree_core/src/fallback_node.cpp
+++ b/behavior_tree_core/src/fallback_node.cpp
@@ -86,6 +86,7 @@ BT::ReturnStatus BT::FallbackNode::Tick()
             }
         }
     }
+    return BT::EXIT;
 }
 
 int BT::FallbackNode::DrawType()

--- a/behavior_tree_core/src/fallback_node_with_memory.cpp
+++ b/behavior_tree_core/src/fallback_node_with_memory.cpp
@@ -115,6 +115,7 @@ BT::ReturnStatus BT::FallbackNodeWithMemory::Tick()
             return child_i_status_;
         }
     }
+    return BT::EXIT;
 }
 
 

--- a/behavior_tree_core/src/sequence_node.cpp
+++ b/behavior_tree_core/src/sequence_node.cpp
@@ -89,6 +89,7 @@ BT::ReturnStatus BT::SequenceNode::Tick()
             }
         }
     }
+    return BT::EXIT;
 }
 
 int BT::SequenceNode::DrawType()

--- a/behavior_tree_core/src/sequence_node_with_memory.cpp
+++ b/behavior_tree_core/src/sequence_node_with_memory.cpp
@@ -117,6 +117,7 @@ BT::ReturnStatus BT::SequenceNodeWithMemory::Tick()
             return child_i_status_;
         }
     }
+    return BT::EXIT;
 }
 
 

--- a/behavior_tree_core/src/tree.cpp
+++ b/behavior_tree_core/src/tree.cpp
@@ -22,7 +22,7 @@ int main(int argc, char **argv)
         int TickPeriod_milliseconds = 1000;
 
         BT::ActionTestNode* action1 = new BT::ActionTestNode("Action 1");
-        BT::ConditionTestNode* condition1 = new BT::ConditionTestNode("Condition 1");
+        // BT::ConditionTestNode* condition1 = new BT::ConditionTestNode("Condition 1");  // commented-out as unused
         BT:: SequenceNode* sequence1 = new BT::SequenceNode("seq1");
 
 
@@ -35,9 +35,10 @@ int main(int argc, char **argv)
         BT:: SequenceNode* sequence3 = new BT::SequenceNode("seq1");
 
 
-        BT::ActionTestNode* action4 = new BT::ActionTestNode("Action 4");
-        BT::ConditionTestNode* condition4 = new BT::ConditionTestNode("Condition 4");
-        BT:: SequenceNode* sequence4 = new BT::SequenceNode("seq1");
+        // Commented-out as unused variables
+        // BT::ActionTestNode* action4 = new BT::ActionTestNode("Action 4");
+        // BT::ConditionTestNode* condition4 = new BT::ConditionTestNode("Condition 4");
+        // BT:: SequenceNode* sequence4 = new BT::SequenceNode("seq1");
 
 
         sequence1->AddChild(condition2);


### PR DESCRIPTION
Fix the build warnings during `catkin_make`.

@miccol In this commit a73dca77dd1a6a01b0284cfc804bc98f1ec2f3d2 I added unconditional returns because the compiler complained.  Please check if the the `BT::EXIT` is a good candidate to return in any case, or it might break functionality.